### PR TITLE
Only invoke scheduled functions once

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,9 @@ function nanotick () {
     if (!interval) {
       interval = true
       delay(function () {
-        for (var i = 0; i < callbacks.length; i++) {
-          callbacks[i]()
+        while (callbacks.length > 0) {
+          var func = callbacks.shift()
+          func()
         }
         interval = false
       })

--- a/test.js
+++ b/test.js
@@ -63,4 +63,25 @@ test('nanotick', function (t) {
       }))()
     }))()
   })
+
+  t.test('scheduled functions should be cleared after their execution', function (t) {
+    t.plan(1)
+
+    var numCalls = 0
+    var tick = nanotick()
+
+    // Arrange for a function to be called on the first tick
+    tick(function () {
+      ++numCalls
+    })()
+
+    process.nextTick(function () {
+      // Arrange for another function to be called on the second tick
+      tick(function () {
+      })()
+      process.nextTick(function () {
+        t.equal(numCalls, 1, 'There should only be one call to a scheduled function')
+      })
+    })
+  })
 })


### PR DESCRIPTION
Nanotick doesn't clear its callback list, so scheduled functions get invoked over and over. This PR rectifies the issue and adds a test.