### PR TITLE
dont ship process.nextTick

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
+/* eslint-disable no-eval */
 var assert = require('assert')
 
 module.exports = nanotick
-
-var delay = (typeof process !== 'undefined' && process.nextTick)
-  ? process.nextTick
-  : (typeof setImmediate !== 'undefined')
+var delay = (typeof window !== 'undefined' && window.document)
+  ? (typeof setImmediate !== 'undefined')
     ? setImmediate
     : setTimeout
+  : eval('process.nextTick')
 
 // Process.nextTick() batching ulity
 // null -> fn(any) -> fn(any)


### PR DESCRIPTION
By checking for window rather than process and using `eval` we can trick browserify into never including the built-in polyfill for `process` :tada: